### PR TITLE
Update zh_cn

### DIFF
--- a/src/main/resources/assets/slate_work/lang/zh_cn.json
+++ b/src/main/resources/assets/slate_work/lang/zh_cn.json
@@ -8,6 +8,7 @@
   "block.slate_work.macro_loci": "法术刻印器",
   "block.slate_work.mute_loci": "抑音石板",
   "block.slate_work.sentinel_loci": "哨卫缓存器",
+  "block.slate_work.broadcaster_loci": "Iota之门",
 
   "Patterns:": "",
   "hexcasting.action.slate_work:get_storage": "获取容具",
@@ -42,7 +43,7 @@
   "slate_work.page.storage_loci.sort_items": "在某些情况下，$(thing)容具/$会变得杂乱无章，同种物品被分散到不同的$(thing)容具/$里去。这条好用的法术就可以整理它们，但它有代价：需消耗 5 个$(l:items/amethyst)充能紫水晶/$。",
   "slate_work.page.storage_loci.set_craft": "为$(l:greatwork/crafting_loci)样板组装器/$设置合成配方。接受包含 $(l:casting/influences)$(thing)Null/$、物品、物品变种的列表，并将此列表应用于目标$(l:greatwork/crafting_loci)组装器/$。",
   "slate_work.page.storage_loci.set_craft_cont": "需要注意，$(l:greatwork/crafting_loci)样板组装器/$会将所给列表“格式化”为从左至右再从上至下的配方。自然，$(l:casting/influences)$(thing)Null/$ 代表配方中的空位。最后提一句，法术会在列表长于 9 个元素时招致事故，少于或等于 9 个时则不会。$(br2)在$(l:greatwork/spellcircles)法术环/$外施放不会招致事故。消耗极少量$(media)媒质/$。",
-  "slate_work.page.storage_loci.set_macro": "此图案会为目标位置处的$(l:greatwork/macro_loci)法术刻印器/$绑定一个图案和一个$(hex)咒术/$。$(br2)在$(l:greatwork/spellcircles)法术环/$外施放不会招致事故。消耗极少量$(media)媒质/$。",
+  "slate_work.page.storage_loci.set_macro": "此图案会为目标位置处的$(l:greatwork/macro_loci)法术刻印器/$绑定一个图案和一个 iota。$(br2)在$(l:greatwork/spellcircles)法术环/$外施放不会招致事故。消耗极少量$(media)媒质/$。",
 
   "slate_work.entry.storage_loci_block": "存储容具",
   "slate_work.page.storage_loci_block.storage_loci": "在忍那些到处都是木刺的笨重$(o)箱子/$到$(o)快忍不下去/$之后……我总算发现了完美的存储方法——$(thing)存储容具/$。$(br)虽然我已经抛弃了一部分意识垃圾，但还不足以直接操作$(thing)存储容具/$。不过，$(l:greatwork/spellcircles)法术环/$就是处理这种新存储方法的好工具。",
@@ -67,9 +68,9 @@
   "slate_work.page.crafting_loci.crafting": "$(thing)样板组装器/$需要熟络典籍和文章，能一目十行的村民的意识。完美之选是$(thing)图书管理员/$。",
 
   "slate_work.entry.macro_loci": "法术刻印器",
-  "slate_work.page.macro_loci.macro_loci": "我在旅行中从其他人的交谈里听到了某种叫“宏”的东西，也即代表咒术的图案（我认为需要和$(l:greatwork/akashiclib)阿卡夏图书馆/$配合？）。即便如此，我也可以在法术环上重现“宏”。需要用到$(thing)法术刻印器/$，还需在刻印器上放置写有$(hex)咒术/$的核心。",
-  "slate_work.page.macro_loci.macro_loci_cont": "$(l:greatwork/spellcircles)法术环/$激活刻印器后，它会将当前图案与核心内的$(hex)咒术/$绑定（也可通过$(l:patterns/spells/storage_loci#slate_work:set_macro)法术/$设置）。每当画有该图案的石板被激活，即会执行所给$(hex)咒术/$，而非该图案。这实在是细思恐极；重写$(o)法术/$的定义，重写与世界本身紧密相关的事物。那么，我是不是也会，被更高级的存在改写？不。不$(k)啊啊啊啊啊！/$",
-  "slate_work.page.macro_loci.lens": "$(thing)法术刻印器/$有个方便的特性：戴着$(l:items/lens)探知透镜/$看它，会显示绑定的图案和该图案对应的$(hex)咒术/$。$(br2)而要是去观察刚……“制造”完毕的$(thing)法术刻印器/$，其中会预先写有一个$(l:patterns/basics#hexcasting:get_caster)意识之精思/$的图案。这一特性很有用，但真是没来由地让人不安……",
+  "slate_work.page.macro_loci.macro_loci": "我在旅行中从其他人的交谈里听到了某种叫“宏”的东西，也即代表咒术的图案（我认为需要和$(l:greatwork/akashiclib)阿卡夏图书馆/$配合？）。即便如此，我也可以在法术环上重现“宏”。需要用到$(thing)法术刻印器/$，还需在刻印器上放置写有 iota 的$(l:items/focus)相应存储物品/$。",
+  "slate_work.page.macro_loci.macro_loci_cont": "$(l:greatwork/spellcircles)法术环/$激活刻印器后，它会将当前图案与存储物品内的 iota 绑定（也可通过$(l:patterns/spells/storage_loci#slate_work:set_macro)法术/$设置）。每当画有该图案的石板被激活，即会执行所给 iota，而非该图案。这实在是细思恐极；重写$(o)法术/$的定义，重写与世界本身紧密相关的事物。那么，我是不是也会，被更高级的存在改写？不。不$(k)啊啊啊啊啊！/$",
+  "slate_work.page.macro_loci.lens": "$(thing)法术刻印器/$有个方便的特性：戴着$(l:items/lens)探知透镜/$看它，会显示绑定的图案和该图案对应的 iota 。$(br2)而要是去观察刚……“制造”完毕的$(thing)法术刻印器/$，其中会预先写有一个$(l:patterns/basics#hexcasting:get_caster)意识之精思/$的图案。这一特性很有用，但真是没来由地让人不安……",
   "slate_work.page.macro_loci.crafting": "虽然这种做法可能会带来恐惧……但还是很好用。我认为$(thing)武器匠/$是最好的选择，他们的专长就是磨砺和翻新损坏的武器。",
 
   "slate_work.entry.mute_loci": "抑音石板",
@@ -105,6 +106,8 @@
   "hexcasting.mishap.circle.no_storage_loci_ran": "%s处未找到已激活的容具",
   "hexcasting.mishap.circle.media_costs": "%s处需要的媒质超出了促动石当前的存储量",
   "hexcasting.mishap.circle.readable": "%s处需要核心中存有列表，而实际没有",
+  "hexcasting.mishap.circle.simpler_iota": "%s处需要一个更简单的iota",
+  "hexcasting.mishap.invalid_value.simpler_iota": "一个更简单的iota",
 
   "hexcasting.mishap.no_storage_loci_ran": "未找到已激活的容具",
   "hexcasting.mishap.list_length": "需要包含%s个元素的列表，而实际包含了%s个",


### PR DESCRIPTION
This shouldn't be merged right now for the sake of proofreading. (Although being `open` at the time )

Proofreaders asked if "cache" in "Sentinel Cache" should be thought as the cache in computer terms, as a "safe space for storing and retrieving," or as a more general "hideout".
Current translation chooses the first one, and the latter two could lead to translation changes; there would be a wider range of word choices than using terms directly.