### PR TITLE
fix Apply Pseudosentinels taking bottom of stack instead of top

### DIFF
--- a/src/main/java/org/sophia/slate_work/casting/actions/sentinel/OpSetSents.kt
+++ b/src/main/java/org/sophia/slate_work/casting/actions/sentinel/OpSetSents.kt
@@ -27,7 +27,7 @@ object OpSetSents : Action {
         }
 
         val args = image.stack.toMutableList()
-        val inputList = args.getList(0,1)
+        val inputList = args.getList(args.lastIndex,1)
         args.removeLast() // I think?
         val realList = mutableListOf<Vec3d>()
         var i = 0


### PR DESCRIPTION
makes Apply Pseudosentinels use the top of the stack.
as far as im aware this is the only spell/pattern with an incorrect argument index