### PR TITLE
fix: OpInduceRestock takes one argument

### DIFF
--- a/src/main/java/org/sophia/slate_work/casting/actions/trades/OpInduceRestock.kt
+++ b/src/main/java/org/sophia/slate_work/casting/actions/trades/OpInduceRestock.kt
@@ -14,7 +14,7 @@ import org.sophia.slate_work.registries.BlockRegistry
 
 object OpInduceRestock : SpellAction {
     override val argc: Int
-        get() = 0
+        get() = 1
 
     override fun execute(
         args: List<Iota>,


### PR DESCRIPTION
Induce Restock currently tries to take zero arguments, which makes it always mishap with a message saying the stack is empty.